### PR TITLE
update eth-testrpc dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,4 @@ pytest==2.6.3
 pytest-pythonpath==0.3
 ethereum==0.9.73
 tox==1.8.0
-# Until https://github.com/ConsenSys/eth-testrpc/pull/16 is merged and
-# released.
-https://github.com/pipermerriam/eth-testrpc/archive/v0.1.15b.tar.gz
+eth-testrpc==0.1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@ click>=5.0
 https://github.com/ethereum/ethash/archive/v23.1.tar.gz
 ethereum>=0.9.73
 requests>=2.7.0
-# Until https://github.com/ConsenSys/eth-testrpc/pull/16 is merged and released.
-https://github.com/pipermerriam/eth-testrpc/archive/v0.1.15b.tar.gz
 pytest==2.7.2


### PR DESCRIPTION
Move the testing dependency on the vendored `eth-testrpc` library to the newly updated pypi version.
