### PR TITLE
Add client methods for eth_blockNumber and eth_accounts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,3 +26,10 @@ def rpc_server():
 
     server.shutdown()
     server.server_close()
+
+
+@pytest.fixture()
+def rpc_client():
+    from eth_rpc_client import Client
+    client = Client('127.0.0.1', '8545')
+    return client

--- a/eth_rpc_client/client.py
+++ b/eth_rpc_client/client.py
@@ -118,3 +118,14 @@ class Client(object):
         """
         response = self.make_rpc_request("eth_getTransactionReceipt", [txn_hash])
         return response['result']
+
+    def get_block_number(self):
+        """
+        https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_blocknumber<F37>
+        """
+        response = self.make_rpc_request("eth_blockNumber", [])
+        return int(response['result'], 16)
+
+    def get_accounts(self):
+        response = self.make_rpc_request("eth_accounts", [])
+        return response['result']

--- a/tests/rpc_client/test_get_accounts.py
+++ b/tests/rpc_client/test_get_accounts.py
@@ -1,0 +1,10 @@
+from ethereum import tester
+
+
+def test_get_accounts(rpc_server, rpc_client):
+    accounts = rpc_client.get_accounts()
+
+    assert len(accounts) == len(tester.accounts)
+
+    for _a, a in zip(accounts, tester.accounts):
+        assert _a == "0x" + tester.encode_hex(a)

--- a/tests/rpc_client/test_get_block_number.py
+++ b/tests/rpc_client/test_get_block_number.py
@@ -1,0 +1,13 @@
+from ethereum import tester
+
+
+def test_get_block(rpc_server, rpc_client, eth_coinbase):
+    block_number = rpc_client.get_block_number()
+    assert block_number == 0
+
+    to_addr = "0x" + tester.encode_hex(tester.accounts[1])
+    txn_hash = rpc_client.send_transaction(_from=eth_coinbase, to=to_addr, value=100)
+    assert txn_hash
+
+    block_number = rpc_client.get_block_number()
+    assert block_number == 1


### PR DESCRIPTION
Adds methods for the `eth_accounts` and `eth_blockNumber` endpoints.
#### Cute animal picture

![petal-and-lupin-in-their-party-hats-hamster-rodent-cute-animal-celebrate-birthday](https://cloud.githubusercontent.com/assets/824194/9415902/97b2e600-47ff-11e5-87a7-dc73cc8a8819.jpg)
