### PR TITLE
Default transactions and calls to be from the coinbaseaddress

### DIFF
--- a/eth_rpc_client/client.py
+++ b/eth_rpc_client/client.py
@@ -34,15 +34,18 @@ def get_transaction_params(_from=None, to=None, gas=None, gas_price=None,
 class Client(object):
     _nonce = 0
 
-    def __init__(self, host, port, defaults=None):
+    def __init__(self, host, port):
         self.host = host
         self.port = port
-        self.defaults = defaults or {}
         self.session = requests.session()
 
     def get_nonce(self):
         self._nonce += 1
         return self._nonce
+
+    @property
+    def default_from_address(self):
+        return self.get_coinbase()
 
     def make_rpc_request(self, method, params):
         response = self.session.post(
@@ -93,7 +96,7 @@ class Client(object):
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call
         """
         if _from is None:
-            _from = self.defaults.get('from')
+            _from = self.default_from_address
 
         params = [
             get_transaction_params(_from, to, gas, gas_price, value, data),
@@ -108,7 +111,7 @@ class Client(object):
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendtransaction
         """
         if _from is None:
-            _from = self.defaults.get('from')
+            _from = self.default_from_address
 
         params = get_transaction_params(_from, to, gas, gas_price, value, data)
 

--- a/tests/rpc_client/test_send_transaction.py
+++ b/tests/rpc_client/test_send_transaction.py
@@ -19,6 +19,21 @@ def test_send_a_transaction(rpc_server, eth_coinbase):
     assert after_balance == 1000004999999999999987655L
 
 
+def test_send_a_transaction_uses_coinbase_as_from(rpc_server, eth_coinbase):
+    client = Client('127.0.0.1', '8545')
+
+    to_addr = tester.encode_hex(tester.accounts[1])
+
+    txn_hash = client.send_transaction(
+        to=to_addr,
+        value=12345,
+    )
+
+    after_balance = client.get_balance(eth_coinbase)
+
+    assert after_balance == 1000004999999999999987655L
+
+
 def test_contract_creation(rpc_server, eth_coinbase):
     client = Client('127.0.0.1', '8545')
 


### PR DESCRIPTION
When sending a transaction, the client will now use the coinbase address as the from address if no address is specified.

![980x](https://cloud.githubusercontent.com/assets/824194/9532724/99715f88-4cca-11e5-94c9-f1f63be80de6.jpg)
