### PR TITLE
Fix get block by xxxx methods

### DIFF
--- a/eth_rpc_client/client.py
+++ b/eth_rpc_client/client.py
@@ -1,4 +1,5 @@
 import json
+import numbers
 import requests
 
 
@@ -139,18 +140,24 @@ class Client(object):
         response = self.make_rpc_request("eth_blockNumber", [])
         return int(response['result'], 16)
 
-    def get_block_by_hash(self, block_hash):
+    def get_block_by_hash(self, block_hash, full_transactions=True):
         """
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbyhash
         """
-        response = self.make_rpc_request("eth_getBlockByHash", [block_hash])
+        response = self.make_rpc_request("eth_getBlockByHash", [block_hash, full_transactions])
         return response['result']
 
-    def get_block_by_number(self, block_number):
+    def get_block_by_number(self, block_number, full_transactions=True):
         """
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber
         """
-        response = self.make_rpc_request("eth_getBlockByNumber", [block_number])
+        if isinstance(block_number, numbers.Number):
+            block_number_as_hex = hex(block_number)
+        else:
+            block_number_as_hex = block_number
+        response = self.make_rpc_request(
+            "eth_getBlockByNumber", [block_number_as_hex, full_transactions],
+        )
         return response['result']
 
     def get_accounts(self):

--- a/tests/rpc_client/test_get_block_by_hash.py
+++ b/tests/rpc_client/test_get_block_by_hash.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ethereum import tester
+
+
+@pytest.mark.xfail
+def test_get_block_by_hash(rpc_server, rpc_client, eth_coinbase):
+    block_number = rpc_client.get_block_number()
+    assert block_number == 0
+
+    to_addr = "0x" + tester.encode_hex(tester.accounts[1])
+    txn_hash = rpc_client.send_transaction(_from=eth_coinbase, to=to_addr, value=100)
+    assert txn_hash
+
+    txn_receipt = rpc_client.get_transaction_receipt(txn_hash)
+    block_hash = txn_receipt['blockHash']
+
+    block = rpc_client.get_block_by_hash(block_hash)
+    assert block

--- a/tests/rpc_client/test_get_block_by_number.py
+++ b/tests/rpc_client/test_get_block_by_number.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ethereum import tester
+
+
+def test_get_block_by_hash(rpc_server, rpc_client, eth_coinbase):
+    block_number = rpc_client.get_block_number()
+    assert block_number == 0
+
+    to_addr = "0x" + tester.encode_hex(tester.accounts[1])
+    txn_hash = rpc_client.send_transaction(_from=eth_coinbase, to=to_addr, value=100)
+    assert txn_hash
+
+    block_number = rpc_client.get_block_number()
+
+    block = rpc_client.get_block_by_number(block_number)
+    assert block


### PR DESCRIPTION
The methds `get_block_by_hash` and `get_block_by_number` were broken as they didn't pass the second parameter for specifying whether transactions should be full or just hashes.  This fixes it.

![b8dfcc924eed695ed20b982990e83fea](https://cloud.githubusercontent.com/assets/824194/9778602/de7e790c-572f-11e5-8fa4-3503887ddd07.jpg)
